### PR TITLE
feat: context menu and log additions

### DIFF
--- a/src/dialogs.py
+++ b/src/dialogs.py
@@ -2198,8 +2198,16 @@ class RollLogDialog(QDialog):
             if len(dice) == 1:
                 d = dice[0]
                 text = f"[{time_str}]  {d['type']} → {d['value']}"
+                color_name = d.get("color_name")
+                if color_name:
+                    text += f"  [{color_name}]"
             else:
-                parts = " + ".join(f"{d['type']}({d['value']})" for d in dice)
+                def _fmt_die(die: dict) -> str:
+                    c = die.get("color_name")
+                    base = f"{die['type']}({die['value']})"
+                    return f"{base}[{c}]" if c else base
+
+                parts = " + ".join(_fmt_die(d) for d in dice)
                 text = f"[{time_str}]  {parts}  =  {total}"
             self._list.addItem(text)
 

--- a/src/die_item.py
+++ b/src/die_item.py
@@ -45,6 +45,8 @@ class DieItem(QGraphicsObject):
     delete_selected_requested = pyqtSignal()        # delete all selected items
     duplicate_requested = pyqtSignal(object)        # self
     rolled              = pyqtSignal(object, int)   # self, final_value
+    accent_apply_requested = pyqtSignal(object)     # (list[DieItem], accent_hex, accent_name)
+    roll_group_requested   = pyqtSignal(object)     # list[DieItem]
 
     def __init__(
         self,
@@ -505,8 +507,18 @@ class DieItem(QGraphicsObject):
         multi = len(sel_dice) > 1
 
         roll_label = f"Roll ({len(sel_dice)})" if multi else "Roll"
-        menu.addAction(roll_label, lambda: [i.roll() for i in sel_dice])
-        if not multi:
+        if multi:
+            def _roll_group() -> None:
+                # Suppress individual roll logs; main window logs once.
+                for i in sel_dice:
+                    i._log_individual = False
+                for i in sel_dice:
+                    i.roll()
+                self.roll_group_requested.emit(sel_dice)
+
+            menu.addAction(roll_label, _roll_group)
+        else:
+            menu.addAction(roll_label, self.roll)
             menu.addAction("Reset", self.reset_value)
         menu.addSeparator()
         if not multi:
@@ -519,8 +531,71 @@ class DieItem(QGraphicsObject):
         menu.addAction(snap_label,    self._toggle_snap)
         menu.addAction(preview_label, self._toggle_hover_preview)
 
+        # Accent apply (color1 override) — applies to currently selected dice
+        accent_label = f"Accent… ({len(sel_dice)})" if multi else "Accent…"
+        accent_menu = menu.addMenu(accent_label)
+        for name, hex_val in self._accent_presets():
+            accent_menu.addAction(name, lambda _=False, h=hex_val, n=name: self._apply_accent_hex(sel_dice, h, n))
+        accent_menu.addSeparator()
+        accent_menu.addAction("Custom…", lambda _=False: self._request_accent_custom(sel_dice, parent))
+
         from PyQt6.QtGui import QCursor
         menu.exec(QCursor.pos())
+
+    @staticmethod
+    def _accent_presets() -> list[tuple[str, str]]:
+        """Named accent palette (hex values stored in dice sets)."""
+        return [
+            ("White", "#ffffff"),
+            ("Black", "#000000"),
+            ("Red", "#ef4444"),
+            ("Orange", "#f97316"),
+            ("Amber", "#f59e0b"),
+            ("Yellow", "#eab308"),
+            ("Lime", "#a3e635"),
+            ("Green", "#22c55e"),
+            ("Emerald", "#10b981"),
+            ("Teal", "#14b8a6"),
+            ("Cyan", "#06b6d4"),
+            ("Sky", "#0ea5e9"),
+            ("Blue", "#3b82f6"),
+            ("Indigo", "#6366f1"),
+            ("Violet", "#8b5cf6"),
+            ("Purple", "#a855f7"),
+            ("Fuchsia", "#d946ef"),
+            ("Pink", "#ec4899"),
+            ("Brown", "#a16207"),
+            ("Sand", "#d6bc8a"),
+        ]
+
+    def _apply_accent_hex(self, sel_dice: list["DieItem"], accent_hex: str, accent_name: str) -> None:
+        """Emit MainWindow request to apply the given accent to the selected dice."""
+        self.accent_apply_requested.emit((sel_dice, accent_hex, accent_name))
+
+    def _request_accent_custom(self, sel_dice: list["DieItem"], parent) -> None:
+        """Prompt for a custom accent color."""
+        from PyQt6.QtWidgets import QColorDialog
+
+        # Use the first dice's current color1 as the initial value.
+        first = sel_dice[0] if sel_dice else self
+        accent_hex = "#ffffff"
+        ds = self._manager.get_set(getattr(first, "set_name", "")) if self._manager else None
+        if ds:
+            raw = ds.colors.get(first.die_type) or next(iter(ds.colors.values()), "#ffffff")
+            if isinstance(raw, str):
+                accent_hex = raw
+            elif isinstance(raw, dict):
+                accent_hex = raw.get("color1", "#ffffff")
+
+        color = QColorDialog.getColor(
+            QColor(accent_hex),
+            parent,
+            "Custom Accent Color (Color 1)",
+        )
+        if not color.isValid():
+            return
+
+        self.accent_apply_requested.emit((sel_dice, color.name(), "Custom"))
 
     def _toggle_snap(self) -> None:
         new_val = not self.grid_snap

--- a/src/drawing_item.py
+++ b/src/drawing_item.py
@@ -200,6 +200,7 @@ class DrawingShapeItem(QGraphicsObject):
     """
 
     delete_requested = pyqtSignal(object)
+    customize_requested = pyqtSignal()  # edit selected shapes via DrawingSettingsDialog
 
     def __init__(
         self,
@@ -234,6 +235,20 @@ class DrawingShapeItem(QGraphicsObject):
         extra = self._stroke_width / 2.0 + 1.0
         return self._rect.adjusted(-extra, -extra, extra, extra)
 
+    def shape(self) -> QPainterPath:
+        # Ensure right-click hit-testing (scene.itemAt) can find this item.
+        # Without an explicit shape(), some platforms default to an
+        # "empty" hit-test region for QGraphicsObject-derived items.
+        from PyQt6.QtGui import QPainterPath as _QPainterPath
+        path = _QPainterPath()
+        extra = self._stroke_width / 2.0 + 1.0
+        hit = self._rect.adjusted(-extra, -extra, extra, extra)
+        if self._shape == "circle":
+            path.addEllipse(hit)
+        else:
+            path.addRect(hit)
+        return path
+
     def paint(self, painter: QPainter, option, widget=None) -> None:
         pen = QPen(self._stroke_color, self._stroke_width)
         pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
@@ -262,10 +277,33 @@ class DrawingShapeItem(QGraphicsObject):
         super().mousePressEvent(event)
 
     def contextMenuEvent(self, event) -> None:
+        from PyQt6.QtGui import QCursor
         from PyQt6.QtWidgets import QMenu
-        menu = QMenu()
-        menu.addAction("Delete", lambda: self.delete_requested.emit(self))
-        menu.exec(event.screenPos().toPoint())
+
+        # Ensure right-clicked shape participates in selection.
+        if not self.isSelected():
+            if self.scene():
+                self.scene().clearSelection()
+            self.setSelected(True)
+
+        scene = self.scene()
+        sel_shapes = [i for i in scene.selectedItems() if isinstance(i, DrawingShapeItem)] if scene else [self]
+        if self not in sel_shapes:
+            sel_shapes = [self] + sel_shapes
+        multi = len(sel_shapes) > 1
+
+        views = scene.views() if scene else []
+        parent = views[0] if views else None
+
+        menu = QMenu(parent)
+
+        customize_label = f"Customize… ({len(sel_shapes)})" if multi else "Customize…"
+        menu.addAction(customize_label, self.customize_requested.emit)
+
+        del_label = f"Delete ({len(sel_shapes)})" if multi else "Delete"
+        menu.addAction(del_label, lambda: [sh.delete_requested.emit(sh) for sh in sel_shapes])
+
+        menu.exec(QCursor.pos())
 
     # ------------------------------------------------------------------
     # Z-order

--- a/src/drawing_settings_dialog.py
+++ b/src/drawing_settings_dialog.py
@@ -98,6 +98,22 @@ class DrawingSettingsDialog(QDialog):
         if x is not None and y is not None:
             self.move(int(x), int(y))
 
+    def refresh_from_settings(self) -> None:
+        """Refresh widget values from the current SettingsManager values.
+
+        Used when a right-click "Customize…" opens this dialog for existing shapes.
+        """
+        self.blockSignals(True)
+        try:
+            self._stroke_spin.setValue(self._settings.drawing("stroke_width"))
+            self._apply_btn_color(self._stroke_btn, self._settings.drawing("stroke_color"))
+            self._apply_btn_color(self._fill_btn, self._settings.drawing("fill_color"))
+            self._opacity_slider.setValue(self._settings.drawing("fill_opacity"))
+            self._opacity_label.setText(f"{self._settings.drawing('fill_opacity')}%")
+            self._snap_chk.setChecked(bool(self._settings.drawing("snap_to_grid")))
+        finally:
+            self.blockSignals(False)
+
     # ------------------------------------------------------------------
     # Public accessors (read current live values)
     # ------------------------------------------------------------------

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -46,7 +46,7 @@ from .measurement_item import MeasurementItem
 from .drawing_settings_dialog import DrawingSettingsDialog
 from .image_item     import ImageItem
 from .die_item       import DieItem
-from .dice_manager   import DiceSetsManager, face_values
+from .dice_manager   import DiceSet, DiceSetsManager, face_values
 from .hand_widget    import HandWidget, _HAND_MARGIN_BOTTOM
 from .models         import CardData, DeckModel
 from .session_manager  import SessionManager
@@ -212,6 +212,8 @@ class MainWindow(QMainWindow):
         self._active_draw_shape  = None           # live DrawingShapeItem during shape drag
         self._draw_start_pos     = None           # QPointF where current shape drag started
         self._draw_settings_dlg  = None           # DrawingSettingsDialog (non-modal, persistent)
+        self._apply_draw_settings_to_selection = False
+        self._draw_customize_needs_undo = False
 
         # Measurement tool
         self._active_measurement: Optional[MeasurementItem] = None  # item being drawn
@@ -1037,6 +1039,8 @@ class MainWindow(QMainWindow):
         di.delete_selected_requested.connect(self._delete_selected)
         di.duplicate_requested.connect(self._on_die_duplicate)
         di.rolled.connect(self._on_die_rolled)
+        di.roll_group_requested.connect(self._on_die_group_rolled)
+        di.accent_apply_requested.connect(self._on_die_accent_apply_requested)
 
     def _on_die_delete(self, di: DieItem) -> None:
         if di in self._die_items:
@@ -1108,12 +1112,84 @@ class MainWindow(QMainWindow):
         """Log a single individual die roll (called via rolled signal)."""
         self._append_roll_log([die])
 
+    def _on_die_group_rolled(self, dice: list) -> None:
+        """Log a multi-die roll as a single line entry."""
+        self._append_roll_log(list(dice))
+
+    def _on_die_accent_apply_requested(self, payload) -> None:
+        """Apply a new accent (Color 1) to the selected dice."""
+        try:
+            dice, accent_hex, accent_name = payload
+        except Exception:
+            return
+        if not dice:
+            return
+
+        self._push_undo()
+
+        # Group by original dice set so we only create one derived set per set.
+        by_set: dict[str, list[DieItem]] = {}
+        for d in dice:
+            by_set.setdefault(d.set_name, []).append(d)
+
+        import uuid as _uuid
+        for old_set_name, dice_in_set in by_set.items():
+            orig = self._dice_manager.get_set(old_set_name)
+            die_types = {d.die_type for d in dice_in_set}
+
+            if orig is None:
+                colors = {dt: accent_hex for dt in die_types}
+                new_set_name = f"{old_set_name} (accent {accent_name}) {_uuid.uuid4().hex[:6]}"
+                new_ds = DiceSet(name=new_set_name, colors=colors, is_builtin=False)
+            else:
+                # Clone all per-die specs, overriding Color 1.
+                colors = {}
+                for dt, raw in orig.colors.items():
+                    if isinstance(raw, str):
+                        colors[dt] = accent_hex
+                    elif isinstance(raw, dict):
+                        spec = dict(raw)
+                        spec["color1"] = accent_hex
+                        colors[dt] = spec
+                    else:
+                        colors[dt] = accent_hex
+
+                # Ensure die types present on the canvas are always defined.
+                for dt in die_types:
+                    colors.setdefault(dt, accent_hex)
+
+                new_set_name = f"{orig.name} (accent {accent_name}) {_uuid.uuid4().hex[:6]}"
+                new_ds = DiceSet(name=new_set_name, colors=colors, is_builtin=False)
+
+            self._dice_manager.add_or_replace_set(new_ds)
+
+            for d in dice_in_set:
+                d.set_name = new_ds.name
+                d.update()
+
     def _append_roll_log(self, dice: list) -> None:
         """Build and store a roll log entry for the given dice (using _final_value)."""
         from datetime import datetime
         time_str = datetime.now().strftime("%H:%M:%S")
+
+        preset_map = {hx.lower(): nm for nm, hx in DieItem._accent_presets()}
+
+        def _die_color_name(d: DieItem) -> str:
+            ds = self._dice_manager.get_set(getattr(d, "set_name", ""))
+            if not ds:
+                return "Custom"
+            raw = ds.colors.get(d.die_type)
+            if raw is None:
+                raw = next(iter(ds.colors.values()), "#ffffff")
+            if isinstance(raw, str):
+                return preset_map.get(raw.lower(), "Custom")
+            if isinstance(raw, dict):
+                c1 = raw.get("color1", "#ffffff")
+                return preset_map.get(str(c1).lower(), "Custom")
+            return "Custom"
+
         dice_entries = [
-            {"type": d.die_type, "value": d._final_value}
+            {"type": d.die_type, "value": d._final_value, "color_name": _die_color_name(d)}
             for d in dice
         ]
         total = sum(e["value"] for e in dice_entries)
@@ -2143,6 +2219,7 @@ class MainWindow(QMainWindow):
                 elif dtype == "shape":
                     item = DrawingShapeItem.from_dict(dd)
                     item.delete_requested.connect(lambda i=item: self._remove_drawing_item(i))
+                    item.customize_requested.connect(self._on_drawing_customize_requested)
                     self._scene.addItem(item)
                     self._drawing_items.append(item)
             except Exception:
@@ -2633,6 +2710,10 @@ class MainWindow(QMainWindow):
 
     def _on_drawing_toggled(self, active: bool) -> None:
         if active:
+            # When using draw tool normally, dialog values apply to new drawings,
+            # not to existing selected shapes.
+            self._apply_draw_settings_to_selection = False
+            self._draw_customize_needs_undo = False
             self._cancel_active_measurement()
             self._view.measurement_active = False
             self._toolbar.set_active_tool("draw")
@@ -2654,6 +2735,8 @@ class MainWindow(QMainWindow):
             self._finalize_active_draw()
             self._close_draw_settings()
         elif tool == "draw":
+            self._apply_draw_settings_to_selection = False
+            self._draw_customize_needs_undo = False
             self._view.setCursor(Qt.CursorShape.CrossCursor)
             self._cancel_active_measurement()
             self._open_draw_settings()
@@ -2810,9 +2893,77 @@ class MainWindow(QMainWindow):
     def _close_draw_settings(self) -> None:
         if self._draw_settings_dlg is not None:
             self._draw_settings_dlg.hide()
+        self._apply_draw_settings_to_selection = False
+        self._draw_customize_needs_undo = False
 
     def _on_draw_settings_changed(self) -> None:
-        pass  # Live settings; no canvas update needed until next stroke/shape
+        from .drawing_item import DrawingShapeItem
+        if not getattr(self, "_apply_draw_settings_to_selection", False):
+            return
+
+        # Apply current dialog values to all selected shape drawings.
+        selected_shapes = [
+            i for i in self._scene.selectedItems()
+            if isinstance(i, DrawingShapeItem)
+        ]
+        if not selected_shapes:
+            return
+
+        # Push undo once, on first user edit after opening via context menu.
+        if getattr(self, "_draw_customize_needs_undo", False):
+            self._push_undo()
+            self._draw_customize_needs_undo = False
+
+        from PyQt6.QtGui import QColor
+
+        stroke_w = self._settings.drawing("stroke_width")
+        stroke_hex = self._settings.drawing("stroke_color")
+        fill_hex = self._settings.drawing("fill_color")
+        fill_op = self._settings.drawing("fill_opacity")  # 0..100
+
+        fill_alpha = int(fill_op * 255 / 100)
+
+        for sh in selected_shapes:
+            sh._stroke_width = stroke_w
+            sh._stroke_color = QColor(stroke_hex)
+            sh._fill_color = QColor(fill_hex)
+            sh._fill_color.setAlpha(fill_alpha)
+            sh.update()
+
+    def _on_drawing_customize_requested(self) -> None:
+        """Open DrawingSettingsDialog preloaded from selected shapes.
+
+        Changes in the dialog are applied live to the selected shapes.
+        """
+        from .drawing_item import DrawingShapeItem
+        selected_shapes = [
+            i for i in self._scene.selectedItems()
+            if isinstance(i, DrawingShapeItem)
+        ]
+        if not selected_shapes:
+            return
+
+        first = selected_shapes[0]
+
+        # Preload drawing settings from the first selected shape.
+        # (When multiple are selected, subsequent edits apply to all.)
+        fill_op = int(round(first._fill_color.alpha() * 100 / 255))
+        self._settings.set_drawing("stroke_width", first._stroke_width)
+        self._settings.set_drawing("stroke_color", first._stroke_color.name())
+        self._settings.set_drawing("fill_color", first._fill_color.name())
+        self._settings.set_drawing("fill_opacity", fill_op)
+        self._settings.save()
+
+        if self._draw_settings_dlg is None:
+            self._open_draw_settings()
+        else:
+            self._draw_settings_dlg.refresh_from_settings()
+            self._draw_settings_dlg.show()
+            self._draw_settings_dlg.raise_()
+
+        # Apply subsequent dialog edits to the selected shapes.
+        self._apply_draw_settings_to_selection = True
+        self._draw_customize_needs_undo = True
 
     def _on_draw_tool_changed(self, sub_tool: str) -> None:
         """Draw sub-tool button changed (freehand/circle/square/eraser)."""
@@ -2912,6 +3063,9 @@ class MainWindow(QMainWindow):
                 self._active_draw_shape.delete_requested.connect(
                     lambda i=self._active_draw_shape: self._remove_drawing_item(i)
                 )
+                self._active_draw_shape.customize_requested.connect(
+                    self._on_drawing_customize_requested
+                )
                 self._drawing_items.append(self._active_draw_shape)
             self._active_draw_shape = None
             self._draw_start_pos = None
@@ -2939,6 +3093,9 @@ class MainWindow(QMainWindow):
                 self._push_undo()
                 self._active_draw_shape.delete_requested.connect(
                     lambda i=self._active_draw_shape: self._remove_drawing_item(i)
+                )
+                self._active_draw_shape.customize_requested.connect(
+                    self._on_drawing_customize_requested
                 )
                 self._drawing_items.append(self._active_draw_shape)
             else:


### PR DESCRIPTION
This pull request adds some quality-of-life things that I'm using in my games:

- A new context menu item that applies a new accent to the selected dice. This is useful when you're rolling multiple dice of the same type and need to tell them apart.
- The dice log should show multiple dice being rolled in a single line (when you roll and select multiple), and the color of the dice.
- A new context menu item for drawings that allows editing the selected shape(s) colors or deleting them